### PR TITLE
Various fixes

### DIFF
--- a/QT/Mall.flow
+++ b/QT/Mall.flow
@@ -35,7 +35,7 @@ void gotoMallLobby()
 {
 	FADE( 2, 0 );
 	FADE_SYNC();
-	CALL_FIELD( 8, 1, 7, 0 );
+	CALL_FIELD( 8, 1, 1, 0 );
 	return;
 }
 

--- a/QT/PortIsland.flow
+++ b/QT/PortIsland.flow
@@ -56,7 +56,7 @@ void gotoPortOutskirts()
 {
 	FADE( 2, 0 );
 	FADE_SYNC();
-	CALL_FIELD( 10, 1, 1, 0 );
+	CALL_FIELD( 10, 2, 0, 0 );
 	return;
 }
 

--- a/QTTest.flow
+++ b/QTTest.flow
@@ -22,6 +22,9 @@ void QuickTravelDisplay()
 		case 9: // Iwatodai Station
 			IwatodaiTravel();
 			break;
+		case 10: // Port Island Station
+			PortIslandTravel();
+			break;
 		default:
 			field_order_party_unhooked();
 			break;

--- a/QTTest.flow
+++ b/QTTest.flow
@@ -238,11 +238,6 @@ void MallTravel()
 	SEL_CHK_PAD(11,7);
 	int select = SEL( Mall );
 	CLOSE_MSG_WIN();
-	if (select < 2)
-	{
-		FADE( 3, 0 );
-		FADE_SYNC();
-	}
 	switch (select)
 	{
 		case 0: // Paulownia Mall


### PR DESCRIPTION
After testing, I discovered the following issues:
1. The menu doesn't open on Port Island Station
2. Travelling to the Station Outskirts travels you to the station instead
3. The entry point is not fitting when travelling from Escapade Club to the Paulownia Mall lobby
4. A duplicate fade animation when travelling inside Paulownia Mall

All of the commits fix these issues.